### PR TITLE
Resource limits jenkins

### DIFF
--- a/template/fabric8-online-che-openshift.yml
+++ b/template/fabric8-online-che-openshift.yml
@@ -350,16 +350,10 @@ items:
               port: 8080
             timeoutSeconds: 10
           volumeMounts:
-          - mountPath: /conf
-            name: che-conf-volume
-            readOnly: false
           - mountPath: /data
             name: che-data-volume
         serviceAccountName: che
         volumes:
-        - name: che-conf-volume
-          persistentVolumeClaim:
-            claimName: che-conf-volume
         - name: che-data-volume
           persistentVolumeClaim:
             claimName: che-data-volume

--- a/template/fabric8-online-che-openshift.yml
+++ b/template/fabric8-online-che-openshift.yml
@@ -21,7 +21,7 @@ items:
     name: object-counts
   spec:
     hard:
-      persistentvolumeclaims: "3"
+      persistentvolumeclaims: "2"
       replicationcontrollers: "20"
       secrets: "20"
       services: "5"
@@ -52,21 +52,21 @@ items:
   spec:
     limits:
     - max:
-        cpu: "2540m"
-        memory: 1300Mi
+        cpu: "2930m"
+        memory: 1500Mi
       min:
         cpu: 29m
         memory: 150Mi
       type: Pod
     - default:
-        cpu: "2540m"
-        memory: 1300Mi
+        cpu: "1"
+        memory: 512Mi
       defaultRequest:
         cpu: 60m
         memory: 307Mi
       max:
-        cpu: "2540m"
-        memory: 1300Mi
+        cpu: "2930m"
+        memory: 1500Mi
       min:
         cpu: 29m
         memory: 150Mi

--- a/template/fabric8-online-che-openshift.yml
+++ b/template/fabric8-online-che-openshift.yml
@@ -159,23 +159,6 @@ items:
       project: che
       version: 1.0.71
       group: io.fabric8.online.apps
-    name: che-conf-volume
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    annotations:
-      maven.fabric8.io/source-url: jar:file:/home/jenkins/workspace/c8-cd_fabric8-online_master-RZCQJXY66EHCHAKJPPRB7OQ2EYEWQC7JYFR7O4VWUBUVXPQNSF5A@2/apps/che/target/che-1.0.71.jar!/META-INF/fabric8/openshift.yml
-    labels:
-      provider: fabric8
-      project: che
-      version: 1.0.71
-      group: io.fabric8.online.apps
     name: che-data-volume
   spec:
     accessModes:

--- a/template/fabric8-online-jenkins-openshift.yml
+++ b/template/fabric8-online-jenkins-openshift.yml
@@ -33,6 +33,37 @@ objects:
       secrets: "40"
       services: "5"
 - apiVersion: v1
+  kind: LimitRange
+  metadata:
+    name: resource-limits
+  spec:
+    limits:
+    - max:
+        cpu: "1368m"
+        memory: "700Mi"
+      min:
+        cpu: "17m"
+        memory: "90Mi"
+      type: Pod
+    - default:
+        cpu: "1"
+        memory: 512Mi
+      defaultRequest:
+        cpu: 60m
+        memory: 307Mi
+      max:
+        cpu: "1368m"
+        memory: 700Mi
+      min:
+        cpu: 17m
+        memory: 90Mi
+      type: Container
+    - max:
+        storage: 1Gi
+      min:
+        storage: 1Gi
+      type: PersistentVolumeClaim
+- apiVersion: v1
   kind: ResourceQuota
   metadata:
     name: compute-resources
@@ -48,8 +79,8 @@ objects:
     name: compute-resources-timebound
   spec:
     hard:
-      limits.cpu: "4"
-      limits.memory: 2Gi
+      limits.cpu: "2"
+      limits.memory: 1Gi
     scopes:
     - Terminating
 - apiVersion: v1


### PR DESCRIPTION
@aslakknutsen this should help normalise the Jenkins resources; we setup a 90Mi claim as minimal to make sure small stuff like the content cache etc can work. Max'ing out Jenkins itself at 700Mi, it should not need anything more than that. Also moving the terminating=jobs to be 1Gi max, since most builds would not need this much ram.

@vpavlin once @aslakknutsen has this in, can you sync your account ( rebuild ? ) and validate.