### PR TITLE
fix(minishift): lets allow configurable host verification

### DIFF
--- a/openshift/init_tenant.go
+++ b/openshift/init_tenant.go
@@ -293,7 +293,13 @@ func executeNamespaceCMD(template string, vars map[string]string, opts ApplyOpti
 	}
 
 	cmdName := "/usr/bin/sh"
-	cmdArgs := []string{"-c", "oc process -f - --server=" + opts.MasterURL + " --token=" + opts.Token + " --namespace=" + opts.Namespace + " | oc apply -f - --server=" + opts.MasterURL + " --token=" + opts.Token + " --namespace=" + opts.Namespace}
+	hostVerify := ""
+	flag := os.Getenv("KEYCLOAK_SKIP_HOST_VERIFY")
+	if strings.ToLower(flag) == "true" {
+		hostVerify = " --insecure-skip-tls-verify=true"
+	}
+
+	cmdArgs := []string{"-c", "oc process -f - --server=" + opts.MasterURL + hostVerify + " --token=" + opts.Token + " --namespace=" + opts.Namespace + " | oc apply -f - --server=" + opts.MasterURL + hostVerify + " --token=" + opts.Token + " --namespace=" + opts.Namespace}
 
 	var buf bytes.Buffer
 	cmd := exec.Command(cmdName, cmdArgs...)


### PR DESCRIPTION
currently when running on minishift we have to disable host verification to be able to run `oc apply`